### PR TITLE
Add property deletion functionality to UI and backend

### DIFF
--- a/BusinessLogic/PropertyService.cs
+++ b/BusinessLogic/PropertyService.cs
@@ -70,6 +70,12 @@ namespace BusinessLogic
             else return false;
         }
 
+        public bool DeleteProperty(int id)
+        {
+            var rowDeleted = _propertyDbService.DeleteProperty(id);
+            return rowDeleted;
+        }
+
         public bool VerifyProperty(PropertyDTO propertyDTO)
         {
             if (!propertyDTO.StreetName.All(char.IsLetter)) return false;

--- a/DataAccess/PropertyDBService.cs
+++ b/DataAccess/PropertyDBService.cs
@@ -135,5 +135,35 @@ namespace DataAccess
             else return true;
         }
 
+
+        public bool DeleteProperty(int id)
+        {
+            string query = "DELETE FROM Properties WHERE Id = @Id";
+
+            int rowsDeleted = 0;
+            try
+            {
+                DbConnect.OpenConnection();
+                using (var command = new SqlCommand(query, DbConnect.GetConnection()))
+                {
+                    command.CommandText = query;
+                    command.Parameters.AddWithValue("@Id", id);
+
+                    rowsDeleted = command.ExecuteNonQuery();
+                }
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("Error in Property removal:" + ex.Message);
+            }
+            finally
+            {
+                DbConnect.CloseConnection();
+            }
+
+            if (rowsDeleted == 0) return false;
+            else return true;
+
+        }
     }
 }

--- a/RealSuite/UserControls/ViewPropertiesPage.Designer.cs
+++ b/RealSuite/UserControls/ViewPropertiesPage.Designer.cs
@@ -35,6 +35,8 @@
             propertiesDataGridView = new DataGridView();
             propertyServiceBindingSource = new BindingSource(components);
             topPanel = new Panel();
+            sletBolig_button = new Button();
+            saveToFileButton = new Button();
             clearTextButton = new Label();
             searchTextBox = new TextBox();
             zipCodeFilterLabel = new Label();
@@ -63,7 +65,6 @@
             listedToDatePicker = new DateTimePicker();
             sellerComboBoxLabel = new Panel();
             sellerComboBox = new ComboBox();
-            saveToFileButton = new Button();
             ((System.ComponentModel.ISupportInitialize)propertiesDataGridView).BeginInit();
             ((System.ComponentModel.ISupportInitialize)propertyServiceBindingSource).BeginInit();
             topPanel.SuspendLayout();
@@ -112,16 +113,17 @@
             propertiesDataGridView.EditMode = DataGridViewEditMode.EditProgrammatically;
             propertiesDataGridView.EnableHeadersVisualStyles = false;
             propertiesDataGridView.GridColor = Color.Gainsboro;
-            propertiesDataGridView.Location = new Point(0, 190);
+            propertiesDataGridView.Location = new Point(0, 183);
             propertiesDataGridView.Margin = new Padding(3, 4, 3, 4);
             propertiesDataGridView.MultiSelect = false;
             propertiesDataGridView.Name = "propertiesDataGridView";
             propertiesDataGridView.RowHeadersVisible = false;
             propertiesDataGridView.RowHeadersWidth = 51;
             propertiesDataGridView.SelectionMode = DataGridViewSelectionMode.FullRowSelect;
-            propertiesDataGridView.Size = new Size(928, 413);
+            propertiesDataGridView.Size = new Size(928, 420);
             propertiesDataGridView.TabIndex = 0;
             propertiesDataGridView.TabStop = false;
+            propertiesDataGridView.CellClick += propertiesDataGridView_CellClick;
             propertiesDataGridView.CellDoubleClick += PropertiesDataGridView_CellDoubleClick;
             // 
             // propertyServiceBindingSource
@@ -131,6 +133,7 @@
             // topPanel
             // 
             topPanel.BackColor = Color.FromArgb(228, 221, 177);
+            topPanel.Controls.Add(sletBolig_button);
             topPanel.Controls.Add(saveToFileButton);
             topPanel.Controls.Add(clearTextButton);
             topPanel.Controls.Add(searchTextBox);
@@ -154,6 +157,27 @@
             topPanel.Size = new Size(928, 181);
             topPanel.TabIndex = 1;
             topPanel.Click += TopPanel_Click;
+            // 
+            // sletBolig_button
+            // 
+            sletBolig_button.Enabled = false;
+            sletBolig_button.Location = new Point(477, 138);
+            sletBolig_button.Name = "sletBolig_button";
+            sletBolig_button.Size = new Size(94, 29);
+            sletBolig_button.TabIndex = 27;
+            sletBolig_button.Text = "Slet bolig";
+            sletBolig_button.UseVisualStyleBackColor = true;
+            sletBolig_button.Click += sletBolig_button_Click;
+            // 
+            // saveToFileButton
+            // 
+            saveToFileButton.Location = new Point(373, 138);
+            saveToFileButton.Name = "saveToFileButton";
+            saveToFileButton.Size = new Size(101, 29);
+            saveToFileButton.TabIndex = 25;
+            saveToFileButton.Text = "Gem liste";
+            saveToFileButton.UseVisualStyleBackColor = true;
+            saveToFileButton.Click += SaveToFileButton_Click;
             // 
             // clearTextButton
             // 
@@ -493,16 +517,6 @@
             sellerComboBox.TabIndex = 18;
             sellerComboBox.SelectedValueChanged += ApplyFilters;
             // 
-            // saveToFileButton
-            // 
-            saveToFileButton.Location = new Point(373, 138);
-            saveToFileButton.Name = "saveToFileButton";
-            saveToFileButton.Size = new Size(101, 29);
-            saveToFileButton.TabIndex = 25;
-            saveToFileButton.Text = "Gem liste";
-            saveToFileButton.UseVisualStyleBackColor = true;
-            saveToFileButton.Click += SaveToFileButton_Click;
-            // 
             // ViewPropertiesPage
             // 
             AutoScaleDimensions = new SizeF(8F, 20F);
@@ -562,5 +576,6 @@
         private Button saveToFileButton;
         private TextBox searchTextBox;
         private Label clearTextButton;
+        private Button sletBolig_button;
     }
 }

--- a/RealSuite/UserControls/ViewPropertiesPage.cs
+++ b/RealSuite/UserControls/ViewPropertiesPage.cs
@@ -1,10 +1,10 @@
-﻿using BusinessLogic;
+﻿using System.Data;
+using System.Diagnostics;
+using BusinessLogic;
 using Models;
 using RealSuite.Events;
 using RealSuite.Interfaces;
 using RealSuite.Services;
-using System.Data;
-using System.Diagnostics;
 
 namespace RealSuite.UserControls
 {
@@ -15,6 +15,7 @@ namespace RealSuite.UserControls
         public event EventHandler<UpdatePropertyEventArgs>? RowDoubleClick;
         private bool _suspendFiltering = false;
         private EnumerableRowCollection<DataRow>? _table;
+        private int? selectedPropertyId = null;
 
         public ViewPropertiesPage(NavigationService navigation)
         {
@@ -260,6 +261,49 @@ namespace RealSuite.UserControls
             ExportService exportService = new(_propertyService.PropertiesSource);
 
             exportService.SaveListToFile();
+        }
+
+        private void propertiesDataGridView_CellClick(object sender, DataGridViewCellEventArgs e)
+        {
+            var index = e.RowIndex;
+            if (e.RowIndex >= 0)
+            {
+                var row = propertiesDataGridView.Rows[index];
+                selectedPropertyId = Convert.ToInt32(row.Cells["Id"].Value);
+                sletBolig_button.Enabled = true;
+            }
+            else
+            {
+                sletBolig_button.Enabled = false;
+            }
+        }
+
+        private void sletBolig_button_Click(object sender, EventArgs e)
+        {
+            if (selectedPropertyId != null)
+            {
+                var confirmResult = MessageBox.Show("Er du sikker på, at du vil slette denne bolig?", "Bekræft sletning",
+                    MessageBoxButtons.YesNo,
+                    MessageBoxIcon.Warning);
+
+                if (confirmResult == DialogResult.Yes)
+                {
+                    bool rowCreated = _propertyService.DeleteProperty((int)selectedPropertyId);
+                    if (rowCreated == true)
+                    {
+                        MessageBox.Show("Boligen blev slettet.", "Succes");
+                        //refresh datagridview??
+                    }
+                    else
+                    {
+                        MessageBox.Show("Boligen kunne ikke slettes.", "Fejl");
+                    }
+                }
+            }
+            else
+            {
+                MessageBox.Show("Vælg venligst en bolig, før du sletter.", "Advarsel");
+            }
         }
     }
 }

--- a/RealSuite/UserControls/ViewPropertiesPage.resx
+++ b/RealSuite/UserControls/ViewPropertiesPage.resx
@@ -117,9 +117,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="propertiesDataGridView.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
   <metadata name="propertyServiceBindingSource.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>


### PR DESCRIPTION
Introduced the ability to delete properties via the UI and backend:
- Added `DeleteProperty(int id)` in `PropertyService.cs` and `PropertyDBService.cs` for backend logic and database interaction.
- Updated `ViewPropertiesPage.Designer.cs` to include a `sletBolig_button` (Delete Property button) and adjusted `propertiesDataGridView` layout and event handling.
- Implemented event handlers in `ViewPropertiesPage.cs` for row selection (`propertiesDataGridView_CellClick`) and property deletion (`sletBolig_button_Click`).
- Added a `selectedPropertyId` field in `ViewPropertiesPage.cs` to track the selected property.
- Removed redundant `saveToFileButton` definitions and adjusted namespaces/imports for clarity.
- Updated `ViewPropertiesPage.resx` to remove `Locked` metadata for `propertiesDataGridView`.

These changes enable property deletion with proper UI feedback and backend integration.