### PR TITLE
Add `DateSold` property to `PropertyDTO` and update usage

### DIFF
--- a/Models/DTOModels/PropertyDTO.cs
+++ b/Models/DTOModels/PropertyDTO.cs
@@ -15,7 +15,7 @@
         public bool Sold { get; set; }
 
         public PropertyDTO(string streetName, int streetNumber, int zipCode, int buildYear,
-            int squareMeters, int sellerId, double price, int realtorId, DateTime dateListed, bool sold)
+            int squareMeters, int sellerId, double price, int realtorId, DateTime dateListed, DateTime? dateSold, bool sold)
         {
             StreetName = streetName;
             StreetNumber = streetNumber;
@@ -26,6 +26,7 @@
             Price = price;
             RealtorId = realtorId;
             DateListed = dateListed;
+            DateSold = dateSold;
             Sold = sold;
         }
     }

--- a/RealSuite/UserControls/AddPropertyPage.cs
+++ b/RealSuite/UserControls/AddPropertyPage.cs
@@ -73,7 +73,7 @@ namespace RealSuite.UserControls
                 Convert.ToInt32(zipcode_textbox.Text), Convert.ToInt32(byggeår_textbox.Text),
                 Convert.ToInt32(kvm_textbox.Text), Convert.ToInt32(sælgerID_textbox.Text),
                 Convert.ToDouble(pris_textbox.Text), Convert.ToInt32(ejendomsmæglerID_textbox.Text),
-                dato_datepicker.Value, solgt_checkbox.Checked);
+                dato_datepicker.Value, solgt_checkbox.Checked ? solgtdato_dateTimePicker.Value : null, solgt_checkbox.Checked);
 
             bool rowCreated = propertyService.CreateProperty(propertyDTO);
 


### PR DESCRIPTION
Added a nullable `DateSold` property to the `PropertyDTO` class to store the sale date of a property. Updated the `PropertyDTO` constructor to include the new parameter. Modified `AddPropertyPage.cs` to conditionally set `DateSold` based on the sold checkbox and date picker values.