### PR TITLE
All CellDoubleClick events on DataViewGrids now only execute if the s…

### DIFF
--- a/RealSuite/UserControls/AddPropertyPage.cs
+++ b/RealSuite/UserControls/AddPropertyPage.cs
@@ -36,16 +36,11 @@ namespace RealSuite.UserControls
 
         private void addSellerGrid_CellDoubleClick(object sender, DataGridViewCellEventArgs e)
         {
-            try
-            {
-                sælgerID_textbox.Text = addSellerGrid.Rows[e.RowIndex].Cells[0].Value.ToString();
-                sælgernavn_textbox.Text = addSellerGrid.Rows[e.RowIndex].Cells[1].Value + " " +
-                                          addSellerGrid.Rows[e.RowIndex].Cells[2].Value;
-                addSellerGrid.Visible = false;
-            }
-            catch (Exception)
-            {
-            }
+            if (e.RowIndex < 0) return;
+            sælgerID_textbox.Text = addSellerGrid.Rows[e.RowIndex].Cells[0].Value.ToString();
+            sælgernavn_textbox.Text = addSellerGrid.Rows[e.RowIndex].Cells[1].Value + " " +
+                                      addSellerGrid.Rows[e.RowIndex].Cells[2].Value;
+            addSellerGrid.Visible = false;
         }
 
         public void Clear()

--- a/RealSuite/UserControls/UpdatePropertyPage.cs
+++ b/RealSuite/UserControls/UpdatePropertyPage.cs
@@ -185,14 +185,11 @@ namespace RealSuite.UserControls
 
         private void addSellerGrid_CellDoubleClick(object sender, DataGridViewCellEventArgs e)
         {
-            try
-            {
-                sælgerID_textbox.Text = addSellerGrid.Rows[e.RowIndex].Cells[0].Value.ToString();
-                sælgernavn_textbox.Text = addSellerGrid.Rows[e.RowIndex].Cells[1].Value + " " +
-                                          addSellerGrid.Rows[e.RowIndex].Cells[2].Value;
-                addSellerGrid.Visible = false;
-            }
-            catch (Exception) { }
+            if (e.RowIndex < 0) return;
+            sælgerID_textbox.Text = addSellerGrid.Rows[e.RowIndex].Cells[0].Value.ToString();
+            sælgernavn_textbox.Text = addSellerGrid.Rows[e.RowIndex].Cells[1].Value + " " +
+                                      addSellerGrid.Rows[e.RowIndex].Cells[2].Value;
+            addSellerGrid.Visible = false;
         }
 
         private void HandleDigit_KeyPress(object sender, KeyPressEventArgs e)

--- a/RealSuite/UserControls/UpdateSellerPage.cs
+++ b/RealSuite/UserControls/UpdateSellerPage.cs
@@ -421,6 +421,7 @@ namespace RealSuite.UserControls
         private void sellerDataGrids_CellDoubleClick(object sender, DataGridViewCellEventArgs e)
         {
             var index = e.RowIndex;
+            if (index < 0) return;
             DataGridView dataGridView = sender as DataGridView;
             var row = dataGridView.Rows[index];
 

--- a/RealSuite/UserControls/ViewPropertiesPage.cs
+++ b/RealSuite/UserControls/ViewPropertiesPage.cs
@@ -238,6 +238,7 @@ namespace RealSuite.UserControls
         private void PropertiesDataGridView_CellDoubleClick(object sender, DataGridViewCellEventArgs e)
         {
             var index = e.RowIndex;
+            if (index < 0) return;
             var row = propertiesDataGridView.Rows[index];
 
             int id = Convert.ToInt32(row.Cells["Id"].Value);

--- a/RealSuite/UserControls/ViewSellersPage.cs
+++ b/RealSuite/UserControls/ViewSellersPage.cs
@@ -198,6 +198,7 @@ namespace RealSuite.UserControls
         private void SellersDataGridView_CellDoubleClick(object sender, DataGridViewCellEventArgs e)
         {
             var index = e.RowIndex;
+            if (index < 0) return;
             var row = sellersDataGridView.Rows[index];
 
             int id = Convert.ToInt32(row.Cells["Id"].Value);


### PR DESCRIPTION
…elected index is 0 or higher.

This prevents it from executing if the header was double clicked.